### PR TITLE
comment_parser: Add Ruby support.

### DIFF
--- a/comment_parser/comment_parser.py
+++ b/comment_parser/comment_parser.py
@@ -2,12 +2,15 @@
 """This program parses various source files and extracts the comment texts.
 
 Currently supported languages:
+  Bash/sh
   C
   C++
   Go
+  HTML
   Java
   Javascript
-  Bash/Sh
+  Ruby
+  XML
 
 Dependencies:
   python-magic: pip install python-magic
@@ -17,11 +20,12 @@ import sys
 
 import magic
 
-from comment_parser.parsers import common
 from comment_parser.parsers import c_parser
+from comment_parser.parsers import common
 from comment_parser.parsers import go_parser
 from comment_parser.parsers import html_parser
 from comment_parser.parsers import js_parser
+from comment_parser.parsers import ruby_parser
 from comment_parser.parsers import shell_parser
 
 MIME_MAP = {
@@ -32,6 +36,7 @@ MIME_MAP = {
     'text/x-go': go_parser,               # Go
     'text/x-java-source': c_parser,       # Java
     'text/x-javascript': js_parser,       # Javascript
+    'text/x-ruby': ruby_parser,           # Ruby
     'text/x-shellscript': shell_parser,   # Unix shell
     'text/xml': html_parser,              # XML
 }

--- a/comment_parser/parsers/ruby_parser.py
+++ b/comment_parser/parsers/ruby_parser.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+"""This module provides methods for parsing comments from Ruby code."""
+
+import re
+from bisect import bisect_left
+from comment_parser.parsers import common
+
+def extract_comments(code):
+  """Extracts a list of comments from the given Ruby source code.
+
+  Comments are represented with the Comment class found in the common module.
+
+  Ruby comments start with a '#' character and run to the end of the line,
+  http://ruby-doc.com/docs/ProgrammingRuby.
+
+  Args:
+    code: String containing code to extract comments from.
+  Returns:
+    Python list of common.Comment in the order that they appear in the code..
+  """
+  pattern = r"""
+    (?P<literal> ((?:'|").*(?:'|"))) |
+    (?P<single> \#(?P<single_content>.*?)$)
+  """
+  compiled = re.compile(pattern, re.VERBOSE | re.MULTILINE)
+
+  lines_indexes = []
+  for match in re.finditer(r"$", code, re.M):
+    lines_indexes.append(match.start())
+
+  comments = []
+  for match in compiled.finditer(code):
+    kind = match.lastgroup
+
+    start_character = match.start()
+    line_no = bisect_left(lines_indexes, start_character)
+
+    if kind == "single":
+      comment_content = match.group("single_content")
+      comment = common.Comment(comment_content, line_no + 1)
+      comments.append(comment)
+
+  return comments

--- a/comment_parser/parsers/tests/ruby_parser_test.py
+++ b/comment_parser/parsers/tests/ruby_parser_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+"""Tests for comment_parser.parsers.ruby_parser.py"""
+
+import unittest
+from comment_parser.parsers import common
+from comment_parser.parsers import shell_parser
+
+
+class ShellParserTest(unittest.TestCase):
+
+  def testComment(self):
+    code = '# comment'
+    comments = shell_parser.extract_comments(code)
+    expected = [common.Comment(code[1:], 1, multiline=False)]
+    self.assertEqual(comments, expected)
+
+  def testCommentInSingleQuotedString(self):
+    code = "'this is # not a comment'"
+    comments = shell_parser.extract_comments(code)
+    self.assertEqual(comments, [])
+
+  def testCommentInDoubleQuotedString(self):
+    code = '"this is # not a comment"'
+    comments = shell_parser.extract_comments(code)
+    self.assertEqual(comments, [])
+
+  def testNestedStringSingleOutside(self):
+    code = "'this is \"# not a comment\"'"
+    comments = shell_parser.extract_comments(code)
+    self.assertEqual(comments, [])
+
+  def testNestedStringDoubleOutside(self):
+    code = '"this is \'# not a comment\'"'
+    comments = shell_parser.extract_comments(code)
+    self.assertEqual(comments, [])
+
+  def testEscapedSingleQuote(self):
+    code = "\\'# this is a comment"
+    comments = shell_parser.extract_comments(code)
+    expected = [common.Comment(code[3:], 1, multiline=False)]
+    self.assertEqual(comments, expected)
+
+  def testEscapedDoubleQuote(self):
+    code = '\\"# this is a comment'
+    comments = shell_parser.extract_comments(code)
+    expected = [common.Comment(code[3:], 1, multiline=False)]
+    self.assertEqual(comments, expected)
+
+  def testDoubleComment(self):
+    code = '# this is not # another comment'
+    comments = shell_parser.extract_comments(code)
+    expected = [common.Comment(code[1:], 1, multiline=False)]
+    self.assertEqual(comments, expected)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
 
 setup(
     name='comment_parser',
-    version='1.1.2',
+    version='1.1.3',
     description='Parse comments from various source files.',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
According to IANA [1] there is no official MIME type for Ruby code. I've
created the unofficial MIME 'text/x-ruby' for this purpose.

I've referenced the "Programming Ruby" guide [2] in creating this
package. It defines a comment as "[starting] with a # character and
run[ning] to the end of the line."

[1] https://www.iana.org/assignments/media-types/media-types.xhtml
[2] http://ruby-doc.com/docs/ProgrammingRuby

Closes #14.