### PR TITLE
comment_parser: Make python-magic an optional dependency.

### DIFF
--- a/comment_parser/comment_parser.py
+++ b/comment_parser/comment_parser.py
@@ -13,12 +13,16 @@ Currently supported languages:
   XML
 
 Dependencies:
-  python-magic: pip install python-magic
+  python-magic: pip install python-magic (optional)
 """
 
 import sys
 
-import magic
+try:
+  import magic
+  has_magic = True
+except ImportError:
+  has_magic = False
 
 from comment_parser.parsers import c_parser
 from comment_parser.parsers import common
@@ -89,6 +93,8 @@ def extract_comments_from_str(code, mime=None):
     UnsupportedError: If code is of an unsupported MIME type.
   """
   if not mime:
+    if not has_magic:
+      raise ImportError('python-magic was not imported')
     mime = magic.from_buffer(code, mime=True)
     if isinstance(mime, bytes):
       mime = mime.decode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name='comment_parser',
-    version='1.1.6',
+    version='1.2.0',
     description='Parse comments from various source files.',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Users may use only extract_comments_from_str, which does not require
libmagic.

>>> from comment_parser import comment_parser
>>> comment_parser.extract_comments('foo.c', mime='text/x-c')
[Comment( Prints Hello World, 4, False)]
>>> comment_parser.extract_comments('foo.c')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jraviles/projects/src/comment_parser/comment_parser/comment_parser.py", line 78, in extract_comments
    return extract_comments_from_str(code.read(), mime)
  File "/home/jraviles/projects/src/comment_parser/comment_parser/comment_parser.py", line 97, in extract_comments_from_str
    raise ImportError('python-magic was not imported')
ImportError: python-magic was not imported

Closes #21