### PR TITLE
comment_parser: Fix build breakage caused by yapf and pylint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
 script:
   - python setup.py test
   - pylint comment_parser
-  - yapf -drp --style=chromium .
+  - yapf -drp --style=yapf .

--- a/comment_parser/comment_parser.py
+++ b/comment_parser/comment_parser.py
@@ -98,7 +98,7 @@ def extract_comments_from_str(code, mime=None):
     parser = MIME_MAP[mime]
     return parser.extract_comments(code)
   except common.Error as e:
-    raise ParseError(str(e))
+    raise ParseError() from e
 
 
 def main(argv):


### PR DESCRIPTION
Deprecated in google/yapf#789.