### PR TITLE
Unicode error resolved while opening a file with utf-8 encoding

### DIFF
--- a/comment_parser/comment_parser.py
+++ b/comment_parser/comment_parser.py
@@ -75,7 +75,7 @@ def extract_comments(filename, mime=None):
   Raises:
     UnsupportedError: If filename is of an unsupported MIME type.
   """
-  with open(filename, 'r') as code:
+  with open(filename, 'r', encoding="utf-8") as code:
     return extract_comments_from_str(code.read(), mime)
 
 


### PR DESCRIPTION
I faced a Unicode error while using the comment_parser module. So tried opening a file(java) with "utf-8" encoding and it worked fine with that particular java file and all other java files. This could be an exceptional case or OS-dependent issue but opening a file in utf-8 which is not in that format will help in avoiding Exceptions.

OS used: Ubuntu-18