### PR TITLE
Python parser can now indentify triple-quoted string comments

### DIFF
--- a/comment_parser/parsers/python_parser.py
+++ b/comment_parser/parsers/python_parser.py
@@ -9,7 +9,7 @@ def extract_comments(code):
   """Extracts a list of comments from the given Python script.
 
   Comments are identified using the tokenize module.
-    - Single-lined comments begin with the '#' character and end with a line-break
+    - Single-lined comments which begin with the '#' character and end with a line-break.
     - Multi-lined comments or docstrings, which are just triple-quoted strings (start 
       and end with ''' or 3 of these "), are told apart from regular strings by the 
       type of the previous token which should be a line-break or an indentation (NEWLINE, 
@@ -26,8 +26,8 @@ def extract_comments(code):
             '''weird syntax anyway''' # <- but still valid indentation
       
       the previous token to the string is the '=' operator and not a line-break or an  
-      indentation. So, only triple-quoted strings preceded by a line-break, an indentation, 
-      or no token, will be considered intended as comments.
+      indentation. That way, only triple-quoted strings preceded by a line-break, an 
+      indentation, or no token, will be considered intended as comments.
 
   Args:
     code: String containing code to extract comments from.

--- a/comment_parser/parsers/python_parser.py
+++ b/comment_parser/parsers/python_parser.py
@@ -5,12 +5,29 @@ import io
 import tokenize
 from comment_parser.parsers import common
 
-
 def extract_comments(code):
   """Extracts a list of comments from the given Python script.
 
-  Comments are identified using the tokenize module. Does not include function,
-  class, or module docstrings. All comments are single line comments.
+  Comments are identified using the tokenize module.
+    - Single-lined comments begin with the '#' character and end with a line-break
+    - Multi-lined comments or docstrings, which are just triple-quoted strings (start 
+      and end with ''' or 3 of these "), are told apart from regular strings by the 
+      type of the previous token which should be a line-break or an indentation (NEWLINE, 
+      NL, INDENT or DEDENT) or no token at all (it would mean it's the fisrt thing in 
+      the script). Even in cases like this: 
+        
+        my_string = \
+        '''this should not be considered a comment'''
+
+        my_string = \
+          '''this should not either''' # <- notice the increasing indentation
+
+        my_string = \
+            '''weird syntax anyway''' # <- but still valid indentation
+      
+      the previous token to the string is the '=' operator and not a line-break or an  
+      indentation. So, only triple-quoted strings preceded by a line-break, an indentation, 
+      or no token, will be considered intended as comments.
 
   Args:
     code: String containing code to extract comments from.
@@ -19,11 +36,24 @@ def extract_comments(code):
   Raises:
     tokenize.TokenError
   """
+  triplequotes = ['"""', "'''"]
+  prevtoknums = [tokenize.NEWLINE, tokenize.NL, tokenize.INDENT, tokenize.DEDENT]
+  prevtoknum = None # Stores the previous token's type.
   comments = []
   tokens = tokenize.tokenize(io.BytesIO(code.encode()).readline)
   for toknum, tokstring, tokloc, _, _ in tokens:
+    # Single-lined comment.
     if toknum is tokenize.COMMENT:
       # Removes leading '#' character.
       tokstring = tokstring[1:]
       comments.append(common.Comment(tokstring, tokloc[0], False))
+      continue
+    # Multi-lined comment.
+    if toknum is tokenize.STRING:
+      if tokstring[:3] in triplequotes and tokstring[-3:] in triplequotes:
+        if (not prevtoknum) or prevtoknum in prevtoknums:
+          # Removes the leading and preceding 3ple quotes (""" or ''').
+          tokstring = tokstring[3:-3]
+          comments.append(common.Comment(tokstring, tokloc[0], True))
+    prevtoknum = toknum
   return comments

--- a/comment_parser/parsers/python_parser.py
+++ b/comment_parser/parsers/python_parser.py
@@ -37,7 +37,7 @@ def extract_comments(code):
     tokenize.TokenError
   """
   triplequotes = ['"""', "'''"]
-  prevtoknums = [tokenize.NEWLINE, tokenize.NL, tokenize.INDENT, tokenize.DEDENT]
+  multicommprevnums = [tokenize.NEWLINE, tokenize.NL, tokenize.INDENT, tokenize.DEDENT]
   prevtoknum = None # Stores the previous token's type.
   comments = []
   tokens = tokenize.tokenize(io.BytesIO(code.encode()).readline)
@@ -51,7 +51,7 @@ def extract_comments(code):
     # Multi-lined comment.
     if toknum is tokenize.STRING:
       if tokstring[:3] in triplequotes and tokstring[-3:] in triplequotes:
-        if (not prevtoknum) or prevtoknum in prevtoknums:
+        if (not prevtoknum) or prevtoknum in multicommprevnums:
           # Removes the leading and preceding 3ple quotes (""" or ''').
           tokstring = tokstring[3:-3]
           comments.append(common.Comment(tokstring, tokloc[0], True))


### PR DESCRIPTION
Python comment parser can now indentify two kinds of comments using the tokenize module.
- Single-lined comments which begin with the `#` character and end with a line-break.
- Multi-lined comments or docstrings, which are just triple-quoted strings (start and end with `'''` or `"""`), are told apart from regular strings by the type of the previous token which should be a line-break or an indentation (`NEWLINE`, `NL`, `INDENT` or `DEDENT`) or no token at all (it would mean it's the fisrt thing in the script). Even in cases like this:

      my_string = \
      '''this should not be considered a comment'''
      my_string = \
        '''this should not either''' # <- notice the increasing indentation
      my_string = \
          '''weird syntax anyway''' # <- but still valid indentation

  the previous token to the string is the `=` operator and not a line-break or an indentation. That way, only triple-quoted strings preceded by a line-break, an indentation, or no token, will be considered intended as comments.

This solves issue https://github.com/jeanralphaviles/comment_parser/issues/33