### PR TITLE
Add support for "text/x-script.python" MIME type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ twine upload dist/*
 | Java        | text/x-java-source       |
 | Javascript  | application/javascript   |
 | Python      | text/x-python            |
+| Python      | text/x-script.python     |
 | Ruby        | text/x-ruby              |
 | Shell       | text/x-shellscript       |
 | XML         | text/xml                 |

--- a/comment_parser/comment_parser.py
+++ b/comment_parser/comment_parser.py
@@ -44,6 +44,7 @@ MIME_MAP = {
     'text/x-javascript': js_parser,  # Javascript
     'text/x-python': python_parser,  # Python
     'text/x-ruby': ruby_parser,  # Ruby
+    'text/x-script.python': python_parser,  # Python
     'text/x-shellscript': shell_parser,  # Unix shell
     'text/xml': html_parser,  # XML
 }

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=readme(),
     long_description_content_type='text/markdown',
     packages=['comment_parser', 'comment_parser.parsers'],
-    install_requires=['python-magic==0.4.18'],
+    install_requires=['python-magic==0.4.24'],
     test_suite='nose.collector',
     tests_require=['nose'],
     zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name='comment_parser',
-    version='1.2.3',
+    version='1.2.4',
     description='Parse comments from various source files.',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Newer versions of OSX Monterey? interpret Python source files as `text/x-script.python`. This adds that MIME to the MIME_MAP.

Fixes #35. 