### PR TITLE
build and publish a wheel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies
-        run: pip install -r requirements.txt
+        run: pip install build
       - name: Build
-        run: python setup.py sdist
+        run: python -m build
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,7 @@ jobs:
       - test
     steps:
       - uses: actions/checkout@v4
+      - name: Install build
+        run: pip install build
       - name: Build
-        run: python setup.py sdist
+        run: python -m build

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ yapf -rip .
 ### Deploying to PyPi
 
 ```shell
-python setup.py sdist
+python -m build
 twine upload dist/*
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 pylint==3.3.3
 pytest==8.3.4
 pytype==2024.10.11
-setuptools==75.6.0
 yapf==0.43.0


### PR DESCRIPTION
among other reasons: protects uses from such as #48.  If the project maintainer publishes a wheel ahead of time, then users are not exposed to breakage when eg setuptools completes a deprecation.